### PR TITLE
Autodetect synced optional fields

### DIFF
--- a/lib/synced/model.rb
+++ b/lib/synced/model.rb
@@ -23,8 +23,9 @@ module Synced
         :synced_local_attributes, :synced_associations, :synced_only_updated
       self.synced_id_key           = options.fetch(:id_key, :synced_id)
       self.synced_all_at_key       = options.fetch(:synced_all_at_key,
-        :synced_all_at)
-      self.synced_data_key         = options.fetch(:data_key, :synced_data)
+        synced_column_presence(:synced_all_at))
+      self.synced_data_key         = options.fetch(:data_key,
+        synced_column_presence(:synced_data))
       self.synced_local_attributes = options.fetch(:local_attributes, [])
       self.synced_associations     = options.fetch(:associations, [])
       self.synced_only_updated     = options.fetch(:only_updated, false)
@@ -75,6 +76,12 @@ module Synced
       }
       synchronizer = Synced::Synchronizer.new(remote, model_class, options)
       synchronizer.perform
+    end
+
+    private
+
+    def synced_column_presence(name)
+      name if column_names.include?(name.to_s)
     end
   end
 end

--- a/spec/dummy/app/models/photo.rb
+++ b/spec/dummy/app/models/photo.rb
@@ -1,5 +1,5 @@
 class Photo < ActiveRecord::Base
-  synced data_key: nil, synced_all_at_key: nil, local_attributes: :filename
+  synced local_attributes: :filename
   belongs_to :location
 
   def self.cancel_all

--- a/spec/lib/synced/model_spec.rb
+++ b/spec/lib/synced/model_spec.rb
@@ -2,6 +2,9 @@ require "spec_helper"
 
 describe Synced::Model do
   class DummyModel < ActiveRecord::Base
+    def self.column_names
+      %w(synced_id synced_all_at synced_data)
+    end
     synced associations: %i(comments votes)
   end
 
@@ -35,21 +38,21 @@ describe Synced::Model do
     end
 
     it "allows to set custom synced_id_key" do
-      klass = Class.new(ActiveRecord::Base) do
+      klass = dummy_model do
         synced id_key: :remote_id
       end
       expect(klass.synced_id_key).to eq :remote_id
     end
 
     it "allows to set custom synced_all_at_key" do
-      klass = Class.new(ActiveRecord::Base) do
+      klass = dummy_model do
         synced synced_all_at_key: :remote_updated_at
       end
       expect(klass.synced_all_at_key).to eq :remote_updated_at
     end
 
     it "allows to set custom synced_data_key" do
-      klass = Class.new(ActiveRecord::Base) do
+      klass = dummy_model do
         synced data_key: :remote_data
       end
       expect(klass.synced_data_key).to eq :remote_data
@@ -67,5 +70,14 @@ describe Synced::Model do
       Rental.synchronize(remote: [remote_object(id: 12,
         updated_at: 2.days.ago)])
     }.to change { Rental.count }.by(1)
+  end
+
+  def dummy_model(&block)
+    klass = Class.new(ActiveRecord::Base) do
+      def self.column_names
+        %w(synced_id synced_data synced_all_at)
+      end
+    end
+    klass.instance_eval &block
   end
 end

--- a/spec/lib/synced/synchronizer_spec.rb
+++ b/spec/lib/synced/synchronizer_spec.rb
@@ -234,7 +234,7 @@ describe Synced::Synchronizer do
     end
   end
 
-  describe "#perform on model with disabled synced_data and synced_all_at" do
+  describe "#perform on model without synced_data and synced_all_at columns" do
     it "synchronizes remote objects correctly" do
       expect {
         Photo.synchronize(remote: [remote_object(id: 17)])


### PR DESCRIPTION
No need to pass data_key: nil, if column is missing then values
will not be assigned.
