### PR TITLE
Add Mappers modules for making attributes conversion easier

### DIFF
--- a/lib/synced/model.rb
+++ b/lib/synced/model.rb
@@ -20,7 +20,8 @@ module Synced
     #   object which will be mapped to local object attributes.
     def synced(options = {})
       class_attribute :synced_id_key, :synced_all_at_key, :synced_data_key,
-        :synced_local_attributes, :synced_associations, :synced_only_updated
+        :synced_local_attributes, :synced_associations, :synced_only_updated,
+        :synced_mapper_module
       self.synced_id_key           = options.fetch(:id_key, :synced_id)
       self.synced_all_at_key       = options.fetch(:synced_all_at_key,
         synced_column_presence(:synced_all_at))
@@ -29,6 +30,7 @@ module Synced
       self.synced_local_attributes = options.fetch(:local_attributes, [])
       self.synced_associations     = options.fetch(:associations, [])
       self.synced_only_updated     = options.fetch(:only_updated, false)
+      self.synced_mapper_module    = options.fetch(:mapper, nil)
       include Synced::HasSyncedData
     end
 
@@ -72,7 +74,8 @@ module Synced
         associations: synced_associations,
         only_updated: synced_only_updated,
         include: include,
-        api: api
+        api: api,
+        mapper: synced_mapper_module
       }
       synchronizer = Synced::Synchronizer.new(remote, model_class, options)
       synchronizer.perform

--- a/spec/dummy/app/models/client.rb
+++ b/spec/dummy/app/models/client.rb
@@ -1,0 +1,13 @@
+class Client < ActiveRecord::Base
+  module SyncedMapper
+    def first_name
+      name.split(' ').first
+    end
+
+    def last_name
+      name.split(' ').last
+    end
+  end
+
+  synced mapper: SyncedMapper, local_attributes: %w(first_name last_name)
+end

--- a/spec/dummy/db/migrate/20140801153935_create_clients.rb
+++ b/spec/dummy/db/migrate/20140801153935_create_clients.rb
@@ -1,0 +1,11 @@
+class CreateClients < ActiveRecord::Migration
+  def change
+    create_table :clients do |t|
+      t.string :first_name
+      t.string :last_name
+      t.integer :synced_id
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140729120659) do
+ActiveRecord::Schema.define(version: 20140801153935) do
 
   create_table "accounts", force: true do |t|
     t.string   "name"
@@ -37,6 +37,14 @@ ActiveRecord::Schema.define(version: 20140729120659) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "reviews_count"
+  end
+
+  create_table "clients", force: true do |t|
+    t.string   "first_name"
+    t.string   "last_name"
+    t.integer  "synced_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "locations", force: true do |t|

--- a/spec/lib/synced/synchronizer_spec.rb
+++ b/spec/lib/synced/synchronizer_spec.rb
@@ -177,6 +177,16 @@ describe Synced::Synchronizer do
           updated_at: Time.now)])
         expect(Amenity.last.name).to eq "wow"
       end
+
+      context "with mapper module" do
+        it "uses methods from mapper" do
+          Client.synchronize(remote:
+            [remote_object(id: 12, name: "Megan Fox")])
+          client = Client.last
+          expect(client.first_name).to eq "Megan"
+          expect(client.last_name).to eq "Fox"
+        end
+      end
     end
 
     context "passed as a hash" do

--- a/spec/vcr_cassettes/deleted_ids_meta.yml
+++ b/spec/vcr_cassettes/deleted_ids_meta.yml
@@ -58,6 +58,6 @@ http_interactions:
       - close
     body:
       encoding: UTF-8
-      string: "{\"bookings\":[{\"id\":1,\"account_id\":1,\"rental_id\":2,\"start_at\":\"2014-04-28T10:55:13Z\",\"end_at\":\"2014-12-28T10:55:34Z\"},{\"id\":4,\"account_id\":1,\"rental_id\":2,\"start_at\":\"2014-04-28T10:55:13Z\",\"end_at\":\"2014-12-28T10:55:34Z\"}],\"meta\":{\"deleted_ids\":[2,17]}}"
+      string: "{\"bookings\":[{\"short_name\":\"one\",\"id\":1,\"account_id\":1,\"rental_id\":2,\"start_at\":\"2014-04-28T10:55:13Z\",\"end_at\":\"2014-12-28T10:55:34Z\"},{\"short_name\":\"one\",\"id\":4,\"account_id\":1,\"rental_id\":2,\"start_at\":\"2014-04-28T10:55:13Z\",\"end_at\":\"2014-12-28T10:55:34Z\"}],\"meta\":{\"deleted_ids\":[2,17]}}"
     http_version:
   recorded_at: Fri, 21 Mar 2014 13:46:19 GMT


### PR DESCRIPTION
When more processing is needed and blocks given to local attributes
become to long Mappers can be used. It's a module which is then
included in the remote object.

```
class Client < ActiveRecord::Base
  module SyncedMapper
    def first_name
      name.split(' ').first
    end

    def last_name
      name.split(' ').last
    end
  end

  synced mapper: SyncedMapper, data_key: nil,
    local_attributes: %w(first_name last_name)
end
```
