### PR TITLE
Allow to define mapper module after synced statement

### DIFF
--- a/lib/synced/synchronizer.rb
+++ b/lib/synced/synchronizer.rb
@@ -48,7 +48,8 @@ module Synced
       @include           = options[:include]
       @local_attributes  = options[:local_attributes]
       @api               = options[:api]
-      @mapper            = options[:mapper]
+      @mapper            = options[:mapper].respond_to?(:call) ?
+                             options[:mapper].call : options[:mapper]
       @associations      = Array(options[:associations])
       @remote_objects    = Array(remote_objects) if remote_objects
       @request_performed = false

--- a/spec/dummy/app/models/booking.rb
+++ b/spec/dummy/app/models/booking.rb
@@ -1,5 +1,9 @@
 class Booking < ActiveRecord::Base
   synced only_updated: true, local_attributes: { name: :short_name,
-    reviews_count: -> (booking) { booking.reviews.size if booking.respond_to?(:reviews) } }
+    reviews_count: -> (booking) { booking.reviews.size if booking.respond_to?(:reviews) } },
+    mapper: -> { EmptyOne }
   belongs_to :account
+
+  module EmptyOne
+  end
 end


### PR DESCRIPTION
it has to be passed as a block otherwise uninitialized constant is
raised
