### PR TITLE
Add fields support

### DIFF
--- a/lib/synced/model.rb
+++ b/lib/synced/model.rb
@@ -30,7 +30,7 @@ module Synced
     def synced(options = {})
       class_attribute :synced_id_key, :synced_all_at_key, :synced_data_key,
         :synced_local_attributes, :synced_associations, :synced_only_updated,
-        :synced_mapper_module, :synced_remove, :synced_include
+        :synced_mapper_module, :synced_remove, :synced_include, :synced_fields
       self.synced_id_key           = options.fetch(:id_key, :synced_id)
       self.synced_all_at_key       = options.fetch(:synced_all_at_key,
         synced_column_presence(:synced_all_at))
@@ -43,6 +43,7 @@ module Synced
       self.synced_mapper_module    = options.fetch(:mapper, nil)
       self.synced_remove           = options.fetch(:remove, false)
       self.synced_include          = options.fetch(:include, [])
+      self.synced_fields           = options.fetch(:fields, nil)
       include Synced::HasSyncedData
     end
 
@@ -76,7 +77,7 @@ module Synced
     #  Rental.synchronize(remote: remote_rentals, scope: website)
     #
     def synchronize(remote: nil, model_class: self, scope: nil, remove: nil,
-      include: nil, api: nil)
+      include: nil, api: nil, fields: nil)
       options = {
         scope:             scope,
         id_key:            synced_id_key,
@@ -87,6 +88,7 @@ module Synced
         associations:      synced_associations,
         only_updated:      synced_only_updated,
         include:           include.nil? ? Array(synced_include) : include,
+        fields:            fields.nil? ? Array(synced_fields) : fields,
         api:               api,
         mapper:            synced_mapper_module
       }

--- a/lib/synced/synchronizer.rb
+++ b/lib/synced/synchronizer.rb
@@ -50,6 +50,7 @@ module Synced
       @api               = options[:api]
       @mapper            = options[:mapper].respond_to?(:call) ?
                              options[:mapper].call : options[:mapper]
+      @fields            = options[:fields]
       @remove            = options[:remove]
       @associations      = Array(options[:associations])
       @remote_objects    = Array(remote_objects) if remote_objects
@@ -168,6 +169,7 @@ module Synced
           options[:include] ||= []
           options[:include] += @include
         end
+        options[:fields] = @fields if @fields.present?
         options[:updated_since] = minimum_updated_at if updated_since_enabled?
         options[:auto_paginate] = true
       end

--- a/spec/dummy/app/models/client.rb
+++ b/spec/dummy/app/models/client.rb
@@ -10,7 +10,7 @@ class Client < ActiveRecord::Base
   end
 
   synced mapper: SyncedMapper, local_attributes: %w(first_name last_name),
-    include: :addresses
+    include: :addresses, fields: [:name]
 
   def self.api
     @@api ||= BookingSync::API::Client.new("CREDENTIALS_FLOW_ACCESS_TOKEN")

--- a/spec/lib/synced/synchronizer_spec.rb
+++ b/spec/lib/synced/synchronizer_spec.rb
@@ -436,7 +436,7 @@ describe Synced::Synchronizer do
       it "passes include to the API request" do
         expect(Client.api).to receive(:paginate)
           .with("clients", { auto_paginate: true,
-            include: [:addresses] })
+            include: [:addresses], fields: [:name] })
           .and_return(remote_objects)
         Client.synchronize
       end
@@ -453,14 +453,34 @@ describe Synced::Synchronizer do
         end
       end
 
-      context "and include in the synchronize method" do
+      context "and include provided in the synchronize method" do
         it "overwrites include from the model" do
           expect(Client.api).to receive(:paginate)
           .with("clients", { auto_paginate: true,
-            include: [:photos] })
+            include: [:photos], fields: [:name] })
           .and_return(remote_objects)
           Client.synchronize(include: [:photos])
         end
+      end
+    end
+  end
+
+  context "when fields: provided in the model" do
+    it "adds fields to the API request" do
+      expect(Client.api).to receive(:paginate)
+        .with("clients", { auto_paginate: true,
+          include: [:addresses], fields: [:name] })
+        .and_return(remote_objects)
+      Client.synchronize
+    end
+
+    context "and fields provided in the synchronize method" do
+      it "overwrites include from the model" do
+        expect(Client.api).to receive(:paginate)
+          .with("clients", { auto_paginate: true,
+            include: [:addresses], fields: [:phone, :type] })
+          .and_return(remote_objects)
+        Client.synchronize(fields: [:phone, :type])
       end
     end
   end


### PR DESCRIPTION
Now you can define which fields will be synchronized. This can
make HTTP response smaller.
