### PR TITLE
Add :delegate_attributes options on synced

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ will be assigned value of `size` attribute of the remote object.
 
 ### Local attributes with mapping blocks
 
-If you want to convert an attributes value during synchronization you can
+If you want to convert attribute's value during synchronization you can
 pass a block as value in the mapping hash. Block will receive remote object
 as the only argument.
 
@@ -358,6 +358,34 @@ This can be overwritten in synchronize method.
 Photo.synchronize(fields: [:name, :size])
 ```
 
+## Delegate attributes
+
+You can delegate attributes from your synced model to `synced_data` Hash for easier access to
+synchronized data.
+
+```ruby
+class Photo < ActiveRecord::Base
+  synced delegate_attributes: [:name]
+end
+```
+
+Now you can fetch photo name using:
+
+```ruby
+@photo.name #=> "Sunny morning"
+```
+
+If you want to access synced attribute with different name, you can pass a Hash:
+
+```ruby
+class Photo < ActiveRecord::Base
+  synced delegate_attributes: {title: :name}
+end
+
+keys are delegated attributes' names and values are keys on synced data Hash. This is a simpler
+version of `delegate :name, to: :synced_data` which works with Hash reserved attributes names, like
+`:zip`, `:map`.
+
 ## Synced configuration options
 
 Option name          | Default value    | Description                                                                       | synced | synchronize |
@@ -372,6 +400,7 @@ Option name          | Default value    | Description                           
 `:include`           | `[]`             | [An array of associations to be fetched](#including-associations-in-synced_data)  | YES    | YES         |
 `:fields`            | `[]`             | [An array of fields to be fetched](#selecting-fields-to-be-synchronized)          | YES    | YES         |
 `:remote`            | `nil`            | [Remote objects to be synchronized with local ones](#synchronization-of-given-remote-objects) | NO | YES |
+`:delegate_attributes`| `[]`            | [Define delegators to synced data Hash attributes](#delegate-attributes) | YES | NO |
 
 ## Documentation
 

--- a/lib/synced/attributes_as_hash.rb
+++ b/lib/synced/attributes_as_hash.rb
@@ -1,0 +1,11 @@
+module Synced
+  module AttributesAsHash
+    # On a Hash returns the same Hash
+    # On an Array returns a Hash with identical corresponding keys and values
+    # Used for mapping local - remote attributes
+    def synced_attributes_as_hash(attributes)
+      return attributes if attributes.is_a?(Hash)
+      Hash[Array(attributes).map { |name| [name, name] }]
+    end
+  end
+end

--- a/lib/synced/delegate_attributes.rb
+++ b/lib/synced/delegate_attributes.rb
@@ -1,0 +1,16 @@
+require 'synced/attributes_as_hash'
+
+module Synced
+  module DelegateAttributes
+    extend ActiveSupport::Concern
+    included do
+      synced_attributes_as_hash(synced_delegate_attributes).each do |key, value|
+        define_method(key) { send(synced_data_key)[value] }
+      end
+    end
+
+    module ClassMethods
+      include Synced::AttributesAsHash
+    end
+  end
+end

--- a/lib/synced/model.rb
+++ b/lib/synced/model.rb
@@ -32,15 +32,18 @@ module Synced
     # @option options [Time|Proc] initial_sync_since: A point in time from which
     #   objects will be synchronized on first synchronization.
     #   Works only for partial (updated_since param) synchronizations.
+    # @option options [Array|Hash] delegate_attributes: Given attributes will be defined
+    #   on synchronized object and delegated to synced_data Hash
     def synced(options = {})
       options.symbolize_keys!
       options.assert_valid_keys(:associations, :data_key, :fields,
         :globalized_attributes, :id_key, :include, :initial_sync_since,
-        :local_attributes, :mapper, :only_updated, :remove, :synced_all_at_key)
+        :local_attributes, :mapper, :only_updated, :remove, :synced_all_at_key,
+        :delegate_attributes)
       class_attribute :synced_id_key, :synced_all_at_key, :synced_data_key,
         :synced_local_attributes, :synced_associations, :synced_only_updated,
         :synced_mapper, :synced_remove, :synced_include, :synced_fields,
-        :synced_globalized_attributes, :synced_initial_sync_since
+        :synced_globalized_attributes, :synced_initial_sync_since, :synced_delegate_attributes
       self.synced_id_key                = options.fetch(:id_key, :synced_id)
       self.synced_all_at_key            = options.fetch(:synced_all_at_key,
         synced_column_presence(:synced_all_at))
@@ -58,6 +61,8 @@ module Synced
         [])
       self.synced_initial_sync_since    = options.fetch(:initial_sync_since,
         nil)
+      self.synced_delegate_attributes   = options.fetch(:delegate_attributes, [])
+      include Synced::DelegateAttributes
       include Synced::HasSyncedData
     end
 
@@ -128,3 +133,4 @@ module Synced
     end
   end
 end
+

--- a/lib/synced/synchronizer.rb
+++ b/lib/synced/synchronizer.rb
@@ -1,7 +1,10 @@
+require 'synced/delegate_attributes'
+require 'synced/attributes_as_hash'
 # Synchronizer class which performs actual synchronization between
 # local database and given array of remote objects
 module Synced
   class Synchronizer
+    include AttributesAsHash
     attr_reader :id_key
 
     # Initializes a new Synchronizer
@@ -51,7 +54,7 @@ module Synced
       @remove                = options[:remove]
       @only_updated          = options[:only_updated]
       @include               = options[:include]
-      @local_attributes      = attributes_as_hash(options[:local_attributes])
+      @local_attributes      = synced_attributes_as_hash(options[:local_attributes])
       @api                   = options[:api]
       @mapper                = options[:mapper].respond_to?(:call) ?
                                options[:mapper].call : options[:mapper]
@@ -60,7 +63,7 @@ module Synced
       @associations          = Array(options[:associations])
       @perform_request       = options[:remote].nil?
       @remote_objects        = Array(options[:remote]) unless @perform_request
-      @globalized_attributes = attributes_as_hash(options[:globalized_attributes])
+      @globalized_attributes = synced_attributes_as_hash(options[:globalized_attributes])
       @initial_sync_since    = options[:initial_sync_since]
     end
 
@@ -238,11 +241,6 @@ module Synced
 
     def instrument(*args, &block)
       Synced.instrumenter.instrument(*args, &block)
-    end
-
-    def attributes_as_hash(attributes)
-      return attributes if attributes.is_a?(Hash)
-      Hash[Array(attributes).map { |name| [name, name] }]
     end
 
     class MissingAPIClient < StandardError

--- a/spec/dummy/app/models/rental.rb
+++ b/spec/dummy/app/models/rental.rb
@@ -1,5 +1,5 @@
 class Rental < ActiveRecord::Base
-  synced
+  synced delegate_attributes: [:total, :zip]
   belongs_to :account
   has_many :periods
 

--- a/spec/lib/synced/model_spec.rb
+++ b/spec/lib/synced/model_spec.rb
@@ -98,7 +98,7 @@ describe Synced::Model do
           expect(error.message).to eq "Unknown key: :i_have_no_memory_of_this_place. " \
             + "Valid keys are: :associations, :data_key, :fields, :globalized_attributes, :id_key, " \
             + ":include, :initial_sync_since, :local_attributes, :mapper, :only_updated, :remove, " \
-            + ":synced_all_at_key"
+            + ":synced_all_at_key, :delegate_attributes"
         }
       end
     end

--- a/spec/lib/synced/synchronizer_spec.rb
+++ b/spec/lib/synced/synchronizer_spec.rb
@@ -611,6 +611,7 @@ describe Synced::Synchronizer do
   end
 
   describe "synced object" do
+    let(:remote_objects) { [remote_object(id: 42, total: 12345, zip: "12-123")] }
     before do
       Timecop.freeze("2013-01-01 15:03:01 UTC") do
         Rental.synchronize(remote: remote_objects)
@@ -624,6 +625,16 @@ describe Synced::Synchronizer do
 
     it "has synced_data to remote object" do
       expect(rental.synced_data).to eq remote_objects.first
+    end
+
+    describe "delegated attributes" do
+      it "returns value from the hash" do
+        expect(rental.total).to eq 12345
+      end
+
+      it "works with hash reserved names" do
+        expect(rental.zip).to eq "12-123"
+      end
     end
   end
 end


### PR DESCRIPTION
It allows to define delegate methods to synced_data Hash, it works
with Hash reserved names like `:zip`, `:map`
