### PR TITLE
Raise expressive error when trying to delete objects without meta data

### DIFF
--- a/lib/synced/synchronizer.rb
+++ b/lib/synced/synchronizer.rb
@@ -172,8 +172,12 @@ module Synced
     end
 
     def deleted_remote_objects_ids
+      meta && meta[:deleted_ids] or raise CannotDeleteDueToNoDeletedIdsError.new(@model_class)
+    end
+
+    def meta
       remote_objects
-      api.last_response.meta[:deleted_ids]
+      @meta ||= api.last_response.meta
     end
 
     def fetch_remote_objects
@@ -256,6 +260,22 @@ module Synced
         else
           %Q{Missing BookingSync API client in #{@model_class} class}
         end
+      end
+    end
+
+    class CannotDeleteDueToNoDeletedIdsError < StandardError
+      def initialize(model_class)
+        @model_class = model_class
+      end
+
+      def message
+        "Cannot delete #{pluralized_model_class}. No deleted_ids were returned in API response."
+      end
+
+      private
+
+      def pluralized_model_class
+        @model_class.to_s.pluralize
       end
     end
   end

--- a/spec/lib/synced/synchronizer_spec.rb
+++ b/spec/lib/synced/synchronizer_spec.rb
@@ -72,6 +72,28 @@ describe Synced::Synchronizer do
         end
       end
 
+      context "deleted_ids are not present in metadata" do
+        let(:remote_objects) { [remote_object(id: 12, name: "test-12")] }
+        let(:account) { Account.create }
+        let!(:booking) { account.bookings.create(synced_id: 10, name: "test-10") }
+
+        before do
+          allow(account.api).to receive(:paginate).with("bookings",
+            { auto_paginate: true, updated_since: nil }).and_return(remote_objects)
+          expect(account.api).to receive(:last_response)
+            .and_return(double({ meta: {} }))
+        end
+
+        it "raises CannotDeleteDueToNoDeletedIdsError" do
+          expect {
+            Booking.synchronize(scope: account, remove: true)
+          }.to raise_error(Synced::Synchronizer::CannotDeleteDueToNoDeletedIdsError) { |ex|
+            msg = "Cannot delete Bookings. No deleted_ids were returned in API response."
+            expect(ex.message).to eq msg
+          }
+        end
+      end
+
       context "when canceled_at column is present" do
         let(:location) { Location.create(name: "Bahamas") }
         let!(:photo) { Photo.create(synced_id: 12) }


### PR DESCRIPTION
Currently if the ```remove``` option is enabled, but there's no meta data in API response, the NoMethodError is raised: ```undefined method `[]' for nil:NilClass```, which doesn't tell much until you look at the code. Would be good to raise something more expressive.