### PR TITLE
Don't search in canceled when performing

### DIFF
--- a/lib/synced/strategies/check.rb
+++ b/lib/synced/strategies/check.rb
@@ -39,6 +39,12 @@ module Synced
         result
       end
 
+      # If we check model which uses cancel instead of destroy, we skip canceled
+      # when searching for additional objects by searching in :visible scope
+      def relation_scope
+        default_remove_strategy == :cancel_all ? super.visible : super
+      end
+
       # Represents result of synchronization integrity check
       class Result
         attr_accessor :model_class, :options, :changed, :missing, :additional

--- a/spec/dummy/app/models/photo.rb
+++ b/spec/dummy/app/models/photo.rb
@@ -9,4 +9,6 @@ class Photo < ActiveRecord::Base
   def cancel
     update_attribute(:canceled_at, Time.now)
   end
+
+  scope :visible, -> { where(canceled_at: nil) }
 end

--- a/spec/lib/synced/strategies/check_spec.rb
+++ b/spec/lib/synced/strategies/check_spec.rb
@@ -56,6 +56,21 @@ describe Synced::Strategies::Check do
     end
   end
 
+  context "when local object is canceled" do
+    let(:location) { Location.create }
+
+    before do
+      location.photos.create synced_id: 19, canceled_at: 2.days.ago
+      allow(Location.api).to receive(:paginate).with("photos", { auto_paginate: true })
+        .and_return([])
+    end
+
+    it "doesn't show as additional object" do
+      differences = Photo.synchronize(scope: location, strategy: :check)
+      expect(differences.additional).to eq []
+    end
+  end
+
   describe Synced::Strategies::Check::Result do
     describe "#passed?" do
       context "when local objects are in sync with remote ones" do


### PR DESCRIPTION
the integrity check