### PR TITLE
Handle search params in .synchronize

### DIFF
--- a/lib/synced/model.rb
+++ b/lib/synced/model.rb
@@ -34,16 +34,19 @@ module Synced
     #   Works only for partial (updated_since param) synchronizations.
     # @option options [Array|Hash] delegate_attributes: Given attributes will be defined
     #   on synchronized object and delegated to synced_data Hash
+    # @option options [Hash] search_params: Given attributes and their values
+    #   which will be passed to api client to perform search
     def synced(options = {})
       options.symbolize_keys!
       options.assert_valid_keys(:associations, :data_key, :fields,
         :globalized_attributes, :id_key, :include, :initial_sync_since,
         :local_attributes, :mapper, :only_updated, :remove, :synced_all_at_key,
-        :delegate_attributes)
+        :delegate_attributes, :search_params)
       class_attribute :synced_id_key, :synced_all_at_key, :synced_data_key,
         :synced_local_attributes, :synced_associations, :synced_only_updated,
         :synced_mapper, :synced_remove, :synced_include, :synced_fields,
-        :synced_globalized_attributes, :synced_initial_sync_since, :synced_delegate_attributes
+        :synced_globalized_attributes, :synced_initial_sync_since, :synced_delegate_attributes,
+        :synced_search_params
       self.synced_id_key                = options.fetch(:id_key, :synced_id)
       self.synced_all_at_key            = options.fetch(:synced_all_at_key,
         synced_column_presence(:synced_all_at))
@@ -62,6 +65,7 @@ module Synced
       self.synced_initial_sync_since    = options.fetch(:initial_sync_since,
         nil)
       self.synced_delegate_attributes   = options.fetch(:delegate_attributes, [])
+      self.synced_search_params         = options.fetch(:search_params, {})
       include Synced::DelegateAttributes
       include Synced::HasSyncedData
     end
@@ -98,10 +102,11 @@ module Synced
     def synchronize(options = {})
       options.symbolize_keys!
       options.assert_valid_keys(:api, :fields, :include, :remote, :remove,
-        :scope, :strategy)
+        :scope, :strategy, :search_params)
       options[:remove]  = synced_remove unless options.has_key?(:remove)
       options[:include] = Array(synced_include) unless options.has_key?(:include)
       options[:fields]  = Array(synced_fields) unless options.has_key?(:fields)
+      options[:search_params] = synced_search_params unless options.has_key?(:search_params)
       options.merge!({
         id_key:                synced_id_key,
         synced_data_key:       synced_data_key,

--- a/spec/dummy/app/models/account.rb
+++ b/spec/dummy/app/models/account.rb
@@ -2,6 +2,10 @@ class Account < ActiveRecord::Base
   has_many :rentals
   has_many :bookings
 
+  def import_bookings_since
+    Time.parse("2015-01-01 12:00:00")
+  end
+
   def api
     @api ||= BookingSync::API.new("ACCESS_TOKEN")
   end

--- a/spec/dummy/app/models/booking.rb
+++ b/spec/dummy/app/models/booking.rb
@@ -1,7 +1,8 @@
 class Booking < ActiveRecord::Base
   synced only_updated: true, local_attributes: { name: :short_name,
     reviews_count: -> (booking) { booking.reviews.size if booking.respond_to?(:reviews) } },
-    mapper: -> { EmptyOne }
+    mapper: -> { EmptyOne },
+    search_params: { from: -> scope { scope.import_bookings_since } }
   belongs_to :account
 
   module EmptyOne

--- a/spec/lib/synced/strategies/full_spec.rb
+++ b/spec/lib/synced/strategies/full_spec.rb
@@ -377,7 +377,7 @@ describe Synced::Strategies::Full do
         }.to change { account.rentals.count }.by(1)
       end
 
-      it "make an api request with auto_paginate enabled" do
+      it "makes an api request with auto_paginate enabled" do
         expect(account.api).to receive(:paginate).with("rentals",
           { auto_paginate: true }).and_return(remote_objects)
         Rental.synchronize(scope: account)
@@ -387,6 +387,14 @@ describe Synced::Strategies::Full do
         Rental.synchronize(scope: account)
         rental = account.rentals.first
         expect(rental.synced_data).to eq(remote_objects.first)
+      end
+
+      it "makes an api request with search params" do
+        from = Time.parse("2010-01-01 12:00:00")
+        expect(account.api).to receive(:paginate)
+          .with("bookings", { auto_paginate: true, from: from, updated_since: nil })
+          .and_return(remote_objects)
+        Booking.synchronize(scope: account, search_params: { from: from })
       end
 
       context "for model with updated since strategy and remove: true" do
@@ -400,7 +408,7 @@ describe Synced::Strategies::Full do
           expect(account.api).to receive(:last_response)
             .and_return(double({ meta: { deleted_ids: [] } }))
           expect {
-            Booking.synchronize(scope: account, remove: true)
+            Booking.synchronize(scope: account, remove: true, search_params: {})
           }.to change { account.bookings.count }.by(1)
         end
       end
@@ -517,14 +525,14 @@ describe Synced::Strategies::Full do
           expect(account.api).to receive(:paginate)
             .with("bookings", { updated_since: "2010-01-01 12:12:12",
               auto_paginate: true }).and_return(remote_objects)
-          Booking.synchronize(scope: account)
+          Booking.synchronize(scope: account, search_params: {})
         end
 
         context "when remove: true" do
           it "destroys local object by ids from response's meta" do
             VCR.use_cassette("deleted_ids_meta") do
               expect {
-                Booking.synchronize(scope: account, remove: true)
+                Booking.synchronize(scope: account, remove: true, search_params: {})
               }.to change { Booking.where(synced_id: 2).count }.from(1).to(0)
             end
           end
@@ -534,7 +542,7 @@ describe Synced::Strategies::Full do
           VCR.use_cassette("deleted_ids_meta") do
             expect {
               expect {
-                Booking.synchronize(scope: account)
+                Booking.synchronize(scope: account, search_params: {})
               }.to change { Booking.find_by(synced_id: 200).synced_all_at }
             }.to change { Booking.find_by(synced_id: 2).synced_all_at }
           end
@@ -574,7 +582,7 @@ describe Synced::Strategies::Full do
             .with("bookings", { updated_since: nil, auto_paginate: true,
               include: [:comments, :reviews] })
             .and_return(remote_objects)
-          Booking.synchronize(scope: account, include: [:comments, :reviews])
+          Booking.synchronize(scope: account, include: [:comments, :reviews], search_params: {})
         end
 
         context "and associations present" do

--- a/spec/lib/synced/strategies/updated_since_spec.rb
+++ b/spec/lib/synced/strategies/updated_since_spec.rb
@@ -19,7 +19,7 @@ describe Synced::Strategies::UpdatedSince do
 
         it "raises CannotDeleteDueToNoDeletedIdsError" do
           expect {
-            Booking.synchronize(scope: account, remove: true)
+            Booking.synchronize(scope: account, remove: true, search_params: {})
           }.to raise_error(Synced::Strategies::UpdatedSince::CannotDeleteDueToNoDeletedIdsError) { |ex|
             msg = "Cannot delete Bookings. No deleted_ids were returned in API response."
             expect(ex.message).to eq msg


### PR DESCRIPTION
In some cases we may want to do some filtering when doing sync, e.g. specify `from` parameter for BookingSearch.