### PR TITLE
Fix remote_objects array wrapping to allow single remote_object sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## master
+  * [bugfix] Fix remote_objects array wrapping to allow single remote_object sync to local association
+
 ## 1.1.1
   * [feature] Allow to filter records with `search_params` when syncing
   * [bugfix] Memoize api instance at strategy level to properly return last_response for meta

--- a/lib/synced/attributes_as_hash.rb
+++ b/lib/synced/attributes_as_hash.rb
@@ -5,7 +5,7 @@ module Synced
     # Used for mapping local - remote attributes
     def synced_attributes_as_hash(attributes)
       return attributes if attributes.is_a?(Hash)
-      Hash[Array(attributes).map { |name| [name, name] }]
+      Hash[Array.wrap(attributes).map { |name| [name, name] }]
     end
   end
 end

--- a/lib/synced/model.rb
+++ b/lib/synced/model.rb
@@ -104,8 +104,8 @@ module Synced
       options.assert_valid_keys(:api, :fields, :include, :remote, :remove,
         :scope, :strategy, :search_params)
       options[:remove]  = synced_remove unless options.has_key?(:remove)
-      options[:include] = Array(synced_include) unless options.has_key?(:include)
-      options[:fields]  = Array(synced_fields) unless options.has_key?(:fields)
+      options[:include] = Array.wrap(synced_include) unless options.has_key?(:include)
+      options[:fields]  = Array.wrap(synced_fields) unless options.has_key?(:fields)
       options[:search_params] = synced_search_params unless options.has_key?(:search_params)
       options.merge!({
         id_key:                synced_id_key,

--- a/lib/synced/strategies/full.rb
+++ b/lib/synced/strategies/full.rb
@@ -59,9 +59,9 @@ module Synced
                                    options[:mapper].call : options[:mapper]
         @fields                = options[:fields]
         @remove                = options[:remove]
-        @associations          = Array(options[:associations])
+        @associations          = Array.wrap(options[:associations])
         @perform_request       = options[:remote].nil?
-        @remote_objects        = Array(options[:remote]) unless @perform_request
+        @remote_objects        = Array.wrap(options[:remote]) unless @perform_request
         @globalized_attributes = synced_attributes_as_hash(options[:globalized_attributes])
         @search_params         = options[:search_params]
       end


### PR DESCRIPTION
Required for https://github.com/BookingSync/bsa-website/pull/372