### PR TITLE
rename search_params as it suggests only using it specifically in sea…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## master
+  * [refactor] Change `search_params` to `query_params`
+
 ## 1.1.3
   * [bugfix] Do not perform requests for blank has_one associations
 

--- a/lib/synced/model.rb
+++ b/lib/synced/model.rb
@@ -34,19 +34,19 @@ module Synced
     #   Works only for partial (updated_since param) synchronizations.
     # @option options [Array|Hash] delegate_attributes: Given attributes will be defined
     #   on synchronized object and delegated to synced_data Hash
-    # @option options [Hash] search_params: Given attributes and their values
+    # @option options [Hash] query_params: Given attributes and their values
     #   which will be passed to api client to perform search
     def synced(options = {})
       options.symbolize_keys!
       options.assert_valid_keys(:associations, :data_key, :fields,
         :globalized_attributes, :id_key, :include, :initial_sync_since,
         :local_attributes, :mapper, :only_updated, :remove, :synced_all_at_key,
-        :delegate_attributes, :search_params)
+        :delegate_attributes, :query_params)
       class_attribute :synced_id_key, :synced_all_at_key, :synced_data_key,
         :synced_local_attributes, :synced_associations, :synced_only_updated,
         :synced_mapper, :synced_remove, :synced_include, :synced_fields,
         :synced_globalized_attributes, :synced_initial_sync_since, :synced_delegate_attributes,
-        :synced_search_params
+        :synced_query_params
       self.synced_id_key                = options.fetch(:id_key, :synced_id)
       self.synced_all_at_key            = options.fetch(:synced_all_at_key,
         synced_column_presence(:synced_all_at))
@@ -65,7 +65,7 @@ module Synced
       self.synced_initial_sync_since    = options.fetch(:initial_sync_since,
         nil)
       self.synced_delegate_attributes   = options.fetch(:delegate_attributes, [])
-      self.synced_search_params         = options.fetch(:search_params, {})
+      self.synced_query_params         = options.fetch(:query_params, {})
       include Synced::DelegateAttributes
       include Synced::HasSyncedData
     end
@@ -102,11 +102,11 @@ module Synced
     def synchronize(options = {})
       options.symbolize_keys!
       options.assert_valid_keys(:api, :fields, :include, :remote, :remove,
-        :scope, :strategy, :search_params, :association_sync)
+        :scope, :strategy, :query_params, :association_sync)
       options[:remove]  = synced_remove unless options.has_key?(:remove)
       options[:include] = Array.wrap(synced_include) unless options.has_key?(:include)
       options[:fields]  = Array.wrap(synced_fields) unless options.has_key?(:fields)
-      options[:search_params] = synced_search_params unless options.has_key?(:search_params)
+      options[:query_params] = synced_query_params unless options.has_key?(:query_params)
       options.merge!({
         id_key:                synced_id_key,
         synced_data_key:       synced_data_key,

--- a/lib/synced/strategies/full.rb
+++ b/lib/synced/strategies/full.rb
@@ -64,7 +64,7 @@ module Synced
         @perform_request       = options[:remote].nil? && !@association_sync
         @remote_objects        = Array.wrap(options[:remote]) unless @perform_request
         @globalized_attributes = synced_attributes_as_hash(options[:globalized_attributes])
-        @search_params         = options[:search_params]
+        @query_params         = options[:query_params]
       end
 
       def perform
@@ -184,11 +184,11 @@ module Synced
           end
           options[:fields] = @fields if @fields.present?
           options[:auto_paginate] = true
-        end.merge(search_params)
+        end.merge(query_params)
       end
 
-      def search_params
-        Hash[@search_params.map do |param, value|
+      def query_params
+        Hash[@query_params.map do |param, value|
           final_value = value.respond_to?(:call) ? search_param_value_for_lambda(value) : value
           [param, final_value]
         end]

--- a/spec/dummy/app/models/booking.rb
+++ b/spec/dummy/app/models/booking.rb
@@ -2,7 +2,7 @@ class Booking < ActiveRecord::Base
   synced only_updated: true, local_attributes: { name: :short_name,
     reviews_count: -> (booking) { booking.reviews.size if booking.respond_to?(:reviews) } },
     mapper: -> { EmptyOne },
-    search_params: { from: -> scope { scope.import_bookings_since } }
+    query_params: { from: -> scope { scope.import_bookings_since } }
   belongs_to :account
 
   def self.api

--- a/spec/lib/synced/model_spec.rb
+++ b/spec/lib/synced/model_spec.rb
@@ -98,7 +98,7 @@ describe Synced::Model do
           expect(error.message).to eq "Unknown key: :i_have_no_memory_of_this_place. " \
             + "Valid keys are: :associations, :data_key, :fields, :globalized_attributes, :id_key, " \
             + ":include, :initial_sync_since, :local_attributes, :mapper, :only_updated, :remove, " \
-            + ":synced_all_at_key, :delegate_attributes, :search_params"
+            + ":synced_all_at_key, :delegate_attributes, :query_params"
         }
       end
     end
@@ -125,7 +125,7 @@ describe Synced::Model do
           Rental.synchronize(i_have_no_memory_of_this_place: true)
         }.to raise_error { |error|
           expect(error.message).to eq "Unknown key: :i_have_no_memory_of_this_place. " \
-            + "Valid keys are: :api, :fields, :include, :remote, :remove, :scope, :strategy, :search_params, :association_sync"
+            + "Valid keys are: :api, :fields, :include, :remote, :remove, :scope, :strategy, :query_params, :association_sync"
         }
       end
     end
@@ -138,8 +138,8 @@ describe Synced::Model do
       end
     end
 
-    context "search_params" do
-      it "uses search_params from class-level declaration accepting lambdas with arity 1
+    context "query_params" do
+      it "uses query_params from class-level declaration accepting lambdas with arity 1
       (with argument being :scope) and passes value to api" do
         account = Account.create(name: "test")
         expect(account.api).to receive(:paginate)
@@ -148,22 +148,22 @@ describe Synced::Model do
         Booking.synchronize(scope: account)
       end
 
-      it "overrides search_params from class-level declaration accepting lambdas with arity 0 and passes value to api" do
+      it "overrides query_params from class-level declaration accepting lambdas with arity 0 and passes value to api" do
         account = Account.create(name: "test")
         from = Time.parse("2010-01-01 12:00:00")
         expect(account.api).to receive(:paginate)
           .with("bookings", { auto_paginate: true, from: from, updated_since: nil })
           .and_return([])
-        Booking.synchronize(scope: account, search_params: { from: -> { from } })
+        Booking.synchronize(scope: account, query_params: { from: -> { from } })
       end
 
-      it "overrides search_params from class-level declaration accepting raw values and passes value to api" do
+      it "overrides query_params from class-level declaration accepting raw values and passes value to api" do
         account = Account.create(name: "test")
         from = Time.parse("2010-01-01 12:00:00")
         expect(account.api).to receive(:paginate)
           .with("bookings", { auto_paginate: true, from: from, updated_since: nil })
           .and_return([])
-        Booking.synchronize(scope: account, search_params: { from: from })
+        Booking.synchronize(scope: account, query_params: { from: from })
       end
     end
   end
@@ -175,7 +175,7 @@ describe Synced::Model do
       allow(account.api).to receive(:paginate).with("bookings",
         { updated_since: nil, auto_paginate: true })
         .and_return(remote_bookings)
-      Booking.synchronize(scope: account, search_params: {})
+      Booking.synchronize(scope: account, query_params: {})
     end
 
     it "resets synced_all_at column" do

--- a/spec/lib/synced/strategies/full_spec.rb
+++ b/spec/lib/synced/strategies/full_spec.rb
@@ -394,7 +394,7 @@ describe Synced::Strategies::Full do
         expect(account.api).to receive(:paginate)
           .with("bookings", { auto_paginate: true, from: from, updated_since: nil })
           .and_return(remote_objects)
-        Booking.synchronize(scope: account, search_params: { from: from })
+        Booking.synchronize(scope: account, query_params: { from: from })
       end
 
       context "for model with updated since strategy and remove: true" do
@@ -408,7 +408,7 @@ describe Synced::Strategies::Full do
           expect(account.api).to receive(:last_response)
             .and_return(double({ meta: { deleted_ids: [] } }))
           expect {
-            Booking.synchronize(scope: account, remove: true, search_params: {})
+            Booking.synchronize(scope: account, remove: true, query_params: {})
           }.to change { account.bookings.count }.by(1)
         end
       end
@@ -541,14 +541,14 @@ describe Synced::Strategies::Full do
           expect(account.api).to receive(:paginate)
             .with("bookings", { updated_since: "2010-01-01 12:12:12",
               auto_paginate: true }).and_return(remote_objects)
-          Booking.synchronize(scope: account, search_params: {})
+          Booking.synchronize(scope: account, query_params: {})
         end
 
         context "when remove: true" do
           it "destroys local object by ids from response's meta" do
             VCR.use_cassette("deleted_ids_meta") do
               expect {
-                Booking.synchronize(scope: account, remove: true, search_params: {})
+                Booking.synchronize(scope: account, remove: true, query_params: {})
               }.to change { Booking.where(synced_id: 2).count }.from(1).to(0)
             end
           end
@@ -558,7 +558,7 @@ describe Synced::Strategies::Full do
           VCR.use_cassette("deleted_ids_meta") do
             expect {
               expect {
-                Booking.synchronize(scope: account, search_params: {})
+                Booking.synchronize(scope: account, query_params: {})
               }.to change { Booking.find_by(synced_id: 200).synced_all_at }
             }.to change { Booking.find_by(synced_id: 2).synced_all_at }
           end
@@ -598,7 +598,7 @@ describe Synced::Strategies::Full do
             .with("bookings", { updated_since: nil, auto_paginate: true,
               include: [:comments, :reviews] })
             .and_return(remote_objects)
-          Booking.synchronize(scope: account, include: [:comments, :reviews], search_params: {})
+          Booking.synchronize(scope: account, include: [:comments, :reviews], query_params: {})
         end
 
         context "and associations present" do

--- a/spec/lib/synced/strategies/updated_since_spec.rb
+++ b/spec/lib/synced/strategies/updated_since_spec.rb
@@ -19,7 +19,7 @@ describe Synced::Strategies::UpdatedSince do
 
         it "raises CannotDeleteDueToNoDeletedIdsError" do
           expect {
-            Booking.synchronize(scope: account, remove: true, search_params: {})
+            Booking.synchronize(scope: account, remove: true, query_params: {})
           }.to raise_error(Synced::Strategies::UpdatedSince::CannotDeleteDueToNoDeletedIdsError) { |ex|
             msg = "Cannot delete Bookings. No deleted_ids were returned in API response."
             expect(ex.message).to eq msg
@@ -37,14 +37,14 @@ describe Synced::Strategies::UpdatedSince do
 
         it "looks for last_response within the same api instance" do
           VCR.use_cassette("deleted_ids_meta") do
-            expect { Booking.synchronize(remove: true, search_params: {}) }.not_to raise_error
+            expect { Booking.synchronize(remove: true, query_params: {}) }.not_to raise_error
           end
         end
 
         it "deletes the booking" do
           VCR.use_cassette("deleted_ids_meta") do
             expect {
-              Booking.synchronize(remove: true, search_params: {})
+              Booking.synchronize(remove: true, query_params: {})
             }.to change { Booking.where(synced_id: 2).count }.from(1).to(0)
           end
         end


### PR DESCRIPTION
…rch endpoints, to just query_params