### PR TITLE
Remove duplicated '@remove = options[:remove]'

### DIFF
--- a/lib/synced/strategies/full.rb
+++ b/lib/synced/strategies/full.rb
@@ -47,7 +47,6 @@ module Synced
         @scope                 = options[:scope]
         @id_key                = options[:id_key]
         @data_key              = options[:data_key]
-        @remove                = options[:remove]
         @only_updated          = options[:only_updated]
         @include               = options[:include]
         @local_attributes      = synced_attributes_as_hash(options[:local_attributes])


### PR DESCRIPTION
Option is set in line https://github.com/BookingSync/synced/blob/fb62b9b69d6493af74bce3463429fbe134017451/lib/synced/strategies/full.rb#L57