### PR TITLE
Use timestamp from server for partial update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     synced (1.3.0)
-      bookingsync-api (>= 0.0.20)
+      bookingsync-api (>= 0.1.3)
       hashie
       rails (>= 4.0.0)
 
@@ -37,7 +37,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.7)
     arel (5.0.1.20140414130214)
-    bookingsync-api (0.0.35)
+    bookingsync-api (0.1.3)
       addressable
       faraday (~> 0.9)
       hashie
@@ -45,12 +45,12 @@ GEM
     celluloid (0.16.0)
       timers (~> 4.0.0)
     coderay (1.1.0)
-    concurrent-ruby (1.0.1)
+    concurrent-ruby (1.0.2)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    faraday (0.9.2)
+    faraday (0.10.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.6)
     formatador (0.2.5)
@@ -66,7 +66,7 @@ GEM
     guard-rspec (4.3.1)
       guard (~> 2.1)
       rspec (>= 2.14, < 4.0)
-    hashie (3.4.3)
+    hashie (3.4.6)
     hitimes (1.2.2)
     i18n (0.6.11)
     json (1.8.1)
@@ -78,9 +78,9 @@ GEM
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
-    mime-types (3.0)
+    mime-types (3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0221)
+    mime-types-data (3.2016.0521)
     minitest (5.4.3)
     multipart-post (2.0.0)
     pry (0.10.1)
@@ -131,7 +131,7 @@ GEM
     rspec-support (3.1.2)
     safe_yaml (1.0.4)
     slop (3.6.0)
-    sprockets (3.6.0)
+    sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (2.3.3)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require 'rspec/rails'
+require 'webmock/rspec'
 
 Rails.backtrace_cleaner.remove_silencers!
 

--- a/synced.gemspec
+++ b/synced.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["span/**/*"]
 
   s.add_dependency "rails", ">= 4.0.0"
-  s.add_dependency "bookingsync-api", ">= 0.0.20"
+  s.add_dependency "bookingsync-api", ">= 0.1.3"
   s.add_dependency "hashie"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
Changes that should solve #29 . As mentioned in discussion, it will require timestamp to be returned in API response. To preserve integrity, MissingTimestapError is raised if there is no `request_timestamp `inside `meta`. 