### PR TITLE
Use pagination with block

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     synced (1.4.0)
-      bookingsync-api (>= 0.1.3)
+      bookingsync-api (>= 0.1.4)
       hashie
       rails (>= 4.0.0)
 
@@ -37,20 +37,21 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.7)
     arel (5.0.1.20140414130214)
-    bookingsync-api (0.1.3)
+    bookingsync-api (0.1.4)
       addressable
       faraday (~> 0.9)
       hashie
+      net-http-persistent (~> 2)
     builder (3.2.2)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     coderay (1.1.1)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.4)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    faraday (0.10.0)
+    faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.14)
     formatador (0.2.5)
@@ -71,7 +72,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    hashie (3.4.6)
+    hashie (3.5.4)
     hitimes (1.2.2)
     i18n (0.6.11)
     json (1.8.3)
@@ -89,6 +90,7 @@ GEM
     minitest (5.10.1)
     multipart-post (2.0.0)
     nenv (0.3.0)
+    net-http-persistent (2.9.4)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -142,7 +144,7 @@ GEM
     safe_yaml (1.0.4)
     shellany (0.0.1)
     slop (3.6.0)
-    sprockets (3.7.0)
+    sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (2.3.3)
@@ -178,4 +180,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/lib/synced/model.rb
+++ b/lib/synced/model.rb
@@ -39,12 +39,12 @@ module Synced
       options.assert_valid_keys(:associations, :data_key, :fields,
         :globalized_attributes, :id_key, :include, :initial_sync_since,
         :local_attributes, :mapper, :only_updated, :remove, :auto_paginate,
-        :delegate_attributes, :query_params, :timestamp_strategy)
+        :delegate_attributes, :query_params, :timestamp_strategy, :handle_processed_objects_proc)
       class_attribute :synced_id_key, :synced_data_key,
         :synced_local_attributes, :synced_associations, :synced_only_updated,
         :synced_mapper, :synced_remove, :synced_include, :synced_fields, :synced_auto_paginate,
         :synced_globalized_attributes, :synced_initial_sync_since, :synced_delegate_attributes,
-        :synced_query_params, :synced_timestamp_strategy, :synced_strategy
+        :synced_query_params, :synced_timestamp_strategy, :synced_strategy, :synced_handle_processed_objects_proc
       self.synced_strategy              = strategy
       self.synced_id_key                = options.fetch(:id_key, :synced_id)
       self.synced_data_key              = options.fetch(:data_key,
@@ -64,6 +64,7 @@ module Synced
       self.synced_query_params          = options.fetch(:query_params, {})
       self.synced_timestamp_strategy    = options.fetch(:timestamp_strategy, nil)
       self.synced_auto_paginate         = options.fetch(:auto_paginate, true)
+      self.synced_handle_processed_objects_proc  = options.fetch(:handle_processed_objects_proc, nil)
       include Synced::DelegateAttributes
       include Synced::HasSyncedData
     end
@@ -116,7 +117,8 @@ module Synced
         mapper:                synced_mapper,
         globalized_attributes: synced_globalized_attributes,
         initial_sync_since:    synced_initial_sync_since,
-        timestamp_strategy:    synced_timestamp_strategy
+        timestamp_strategy:    synced_timestamp_strategy,
+        handle_processed_objects_proc:  synced_handle_processed_objects_proc
       })
       Synced::Synchronizer.new(self, options).perform
     end

--- a/spec/dummy/app/models/client.rb
+++ b/spec/dummy/app/models/client.rb
@@ -10,7 +10,7 @@ class Client < ActiveRecord::Base
   end
 
   synced mapper: SyncedMapper, local_attributes: %w(first_name last_name),
-    include: :addresses, fields: [:name], strategy: :full
+    include: :addresses, fields: [:name], strategy: :full, auto_paginate: false
 
   def self.api
     BookingSync::API::Client.new("CREDENTIALS_FLOW_ACCESS_TOKEN")

--- a/spec/dummy/app/models/rental.rb
+++ b/spec/dummy/app/models/rental.rb
@@ -1,8 +1,16 @@
 class Rental < ActiveRecord::Base
-  synced delegate_attributes: [:total, :zip], strategy: :full
+  synced delegate_attributes: [:total, :zip], strategy: :full, auto_paginate: false,
+    handle_processed_objects_proc: Proc.new { |processed_objects|
+      processed_objects.each do |rental|
+        rental.name = "#{rental.synced_data.name}_modified"
+        rental.save
+      end
+    }
   belongs_to :account
   has_many :periods
   has_many :los_records
+
+  validates :synced_id, presence: true
 
   def import_periods_since
     Time.parse('2009-04-19 14:44:32')

--- a/spec/lib/synced/strategies/check_spec.rb
+++ b/spec/lib/synced/strategies/check_spec.rb
@@ -9,7 +9,7 @@ describe Synced::Strategies::Check do
 
   before do
     allow(account.api).to receive(:paginate).with("rentals",
-      { auto_paginate: true }).and_return(remote_rentals)
+      { per_page: 50 }).and_yield(remote_rentals)
   end
 
   it "returns hash with differences" do

--- a/spec/models/rental_spec.rb
+++ b/spec/models/rental_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Rental do
   it "saves and retrieves synced data" do
-    rental = Rental.create(synced_data: { test: "ok" } )
+    rental = Rental.create(synced_id: 35, synced_data: { test: "ok" } )
     expect(rental.synced_data.test).to eq 'ok'
   end
 

--- a/synced.gemspec
+++ b/synced.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["span/**/*"]
 
   s.add_dependency "rails", ">= 4.0.0"
-  s.add_dependency "bookingsync-api", ">= 0.1.3"
+  s.add_dependency "bookingsync-api", ">= 0.1.4"
   s.add_dependency "hashie"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
Instead of fetching all records at once, allow to persist them in batches. Reduces memory usage, but increases total sync time (in theory).
Changes in `bookingsync-api` are required, since right now it doesn't handle pagination with block, if only one page is returned.

<s>May require some additional changes in other apps if they override `synchronize` method (array of all fetched records can't be returned anymore, so for example calling `super` and doing some additional operations on fetched records won't work anymore)</s> 
`auto_paginate` strategy is backwards compatible, so should work without any changes.