### PR TITLE
Support tolerance param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* [feature] Synced will accept tolerance param which reduces updated_since value by specified amount of seconds.
+
 ## 1.6.1 - 2017-10-12
 
 * [improvement] Move default value of `data_key` fetch to block.
@@ -10,7 +12,7 @@
 * [enhancement] Support only Ruby 2.3+
 
 ## 1.5.2
-  * [bugfix] Fix n + 1 querry problems
+  * [bugfix] Fix n + 1 query problems
   * [feature] Allow to choose method of fetching data (with auto_paginate or in batches). Fetching in batches should reduce memory usage. Defaults to auto_paginate, hence no changes required after update.
   * [improvement] Update bookingsync-api gem to 0.1.4
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,27 @@ end
 This strategy is added to fix the problems with massive updates on `synced_all_at`. Proper cleanup of timestamp records
 is needed once in a while with `Synced::Timestamp.cleanup` (cleans records older than 1 week).
 
+### Syncing with offset
+
+Sometimes (mostly for pricing related endpoints like LOS Records or Rates) sync request
+is made during transaction. That can make your local database out of sync, usually due to
+older records not being removed. For such cases there is `tolerance` option which will
+reduce `updated_since` value by specified amount of seconds. That way, if your last request has
+been made during transaction, everything will heal itself during next sync.
+
+For example:
+
+```ruby
+class Rental < ActiveRecord::Base
+  synced tolerance: 60
+end
+```
+
+Will always reduce `updated_since` param by 60 seconds.
+Setting this value too high can cause re-fetching same changes multiple time, which
+may exhaust rate limits of your application much faster and increase overall sync time.
+
+
 ### Forcing local objects to be re-synced with the API
 
 When you add a new column or change something in the synced attributes and you
@@ -496,6 +517,7 @@ Option name          | Default value    | Description                           
 `:auto_paginate`     | `true`           | [Whether data should be fetched in batches or as one response](#fetching-methods)                 | YES    | YES |
 `:transaction_per_page` | `false`       | [Whether transaction should be per page of fetched objects or for all the pages - note that setting this value to `true` will mean always fetching data in batches, even when specifying `auto_paginate` as true](#persisting-fetched-objects)                 | YES    | YES |
 `:handle_processed_objects_proc` | `nil` | [Custom proc taking persisted remote objects, called after persisting batch of data](#persisted-objects)   | YES    | NO |
+`:tolerance`         | 0                | [How many seconds updated_since param should be reduced during request](#syncing-with-offset) | YES | NO |
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -307,8 +307,8 @@ end
 ```
 
 Will always reduce `updated_since` param by 60 seconds.
-Setting this value too high can cause re-fetching same changes multiple time, which
-may exhaust rate limits of your application much faster and increase overall sync time.
+Setting this value too high can cause re-fetching same changes multiple times, which
+may exhaust rate limit of your application much faster and increase overall sync time.
 
 
 ### Forcing local objects to be re-synced with the API

--- a/lib/synced/strategies/updated_since.rb
+++ b/lib/synced/strategies/updated_since.rb
@@ -44,7 +44,11 @@ module Synced
 
       def updated_since
         instrument("updated_since.synced") do
-          [@timestamp_strategy.last_synced_at, initial_sync_since].compact.max
+          last_synced_at_offset = ENV.fetch("LAST_SYNCED_AT_OFFSET", 0).to_i
+          [
+            @timestamp_strategy.last_synced_at&.advance(seconds: last_synced_at_offset),
+            initial_sync_since
+          ].compact.max
         end
       end
 

--- a/spec/lib/synced/model_spec.rb
+++ b/spec/lib/synced/model_spec.rb
@@ -65,7 +65,8 @@ describe Synced::Model do
           expect(error.message).to eq "Unknown key: :i_have_no_memory_of_this_place. " \
             + "Valid keys are: :associations, :data_key, :fields, :globalized_attributes, :id_key, " \
             + ":include, :initial_sync_since, :local_attributes, :mapper, :only_updated, :remove, " \
-            + ":auto_paginate, :transaction_per_page, :delegate_attributes, :query_params, :timestamp_strategy, :handle_processed_objects_proc"
+            + ":auto_paginate, :transaction_per_page, :delegate_attributes, :query_params, :timestamp_strategy, " \
+            + ":handle_processed_objects_proc, :tolerance"
         }
       end
     end

--- a/spec/lib/synced/strategies/updated_since_spec.rb
+++ b/spec/lib/synced/strategies/updated_since_spec.rb
@@ -111,10 +111,16 @@ describe Synced::Strategies::UpdatedSince do
       context "with tolerance specified" do
         let(:request_timestamp) { 1.year.ago }
 
-        around do
+        before do
           LosRecord.instance_eval do
             synced strategy: :updated_since, timestamp_strategy: Synced::Strategies::SyncedPerScopeTimestampStrategy,
               tolerance: 60
+          end
+        end
+
+        after do
+          LosRecord.instance_eval do
+            synced strategy: :updated_since, timestamp_strategy: Synced::Strategies::SyncedPerScopeTimestampStrategy
           end
         end
 

--- a/spec/lib/synced/strategies/updated_since_spec.rb
+++ b/spec/lib/synced/strategies/updated_since_spec.rb
@@ -108,30 +108,52 @@ describe Synced::Strategies::UpdatedSince do
         end
       end
 
-      context "with ENV['LAST_SYNCED_AT_OFFSET'] specified" do
+      context "with tolerance specified" do
         let(:request_timestamp) { 1.year.ago }
 
-        before do
-          ENV["LAST_SYNCED_AT_OFFSET"] = "-60"
-          Synced::Timestamp.with_scope_and_model(account, LosRecord).create(synced_at: Time.zone.parse("2010-01-01 12:12:12 UTC"))
-          # we defined offset on -60 seconds so query should have updated since equal to 2010-01-01 12:11:12 UTC
-          stub_request(:get, "https://www.bookingsync.com/api/v3/los_records?updated_since=2010-01-01%2012:11:12%20UTC").
-            to_return(
-              status: 200,
-              body: { "los_records" => [], "meta" => { "deleted_ids" => [] } }.to_json,
-              headers: { "x-updated-since-request-synced-at" => request_timestamp.to_s }
-            )
+        around do
+          LosRecord.instance_eval do
+            synced strategy: :updated_since, timestamp_strategy: Synced::Strategies::SyncedPerScopeTimestampStrategy,
+              tolerance: 60
+          end
         end
 
-        after do
-          ENV.delete("LAST_SYNCED_AT_OFFSET")
+        context "initial sync" do
+          before do
+            stub_request(:get, "https://www.bookingsync.com/api/v3/los_records?updated_since")
+              .to_return(
+                status: 200,
+                body: { "los_records" => [], "meta" => { "deleted_ids" => [] } }.to_json,
+                headers: { "x-updated-since-request-synced-at" => request_timestamp.to_s }
+              )
+          end
+
+          it "synchronizes records without specifying updated_since" do
+            expect(account.api).to receive(:paginate).with(
+              "los_records", hash_including(updated_since: nil)
+            ).and_call_original
+            LosRecord.synchronize(scope: account, remove: true, query_params: {})
+          end
         end
 
-        it "synchronizes los by using timestamp changed by amount of seconds defined by LAST_SYNCED_AT_OFFSET" do
-          expect(account.api).to receive(:paginate).with(
-            "los_records", hash_including(updated_since: Time.zone.parse("2010-01-01 12:11:12 UTC"))
-          ).and_call_original
-          LosRecord.synchronize(scope: account, remove: true, query_params: {})
+        context "with earlier syncs present" do
+          before do
+            Synced::Timestamp.with_scope_and_model(account, LosRecord).create(synced_at: Time.zone.parse("2010-01-01 12:12:12 UTC"))
+            # we defined offset tolerance of 60 seconds so query should have updated since equal to 2010-01-01 12:11:12 UTC
+            stub_request(:get, "https://www.bookingsync.com/api/v3/los_records?updated_since=2010-01-01%2012:11:12%20UTC")
+              .to_return(
+                status: 200,
+                body: { "los_records" => [], "meta" => { "deleted_ids" => [] } }.to_json,
+                headers: { "x-updated-since-request-synced-at" => request_timestamp.to_s }
+              )
+          end
+
+          it "synchronizes records using timestamp reduced by amount of seconds defined specified by :tolerance" do
+            expect(account.api).to receive(:paginate).with(
+              "los_records", hash_including(updated_since: Time.zone.parse("2010-01-01 12:11:12 UTC"))
+            ).and_call_original
+            LosRecord.synchronize(scope: account, remove: true, query_params: {})
+          end
         end
       end
     end


### PR DESCRIPTION
there is possible issue with often sync and longer (few seconds) transactions on BookingSync. Can result in data that would never be fetched using updated_since logic.